### PR TITLE
Manage Cocoapods CDN

### DIFF
--- a/lib/ad_licenselint/runner.rb
+++ b/lib/ad_licenselint/runner.rb
@@ -3,7 +3,12 @@ module ADLicenseLint
   class Runner
     attr_accessor :options, :path
 
-    POD_SOURCE = Pod::Source.new("~/.cocoapods/repos/master")
+    COCOAPODS_REPOS = ENV["HOME"] + "/.cocoapods/repos/"
+    if File.exist?(COCOAPODS_REPOS + "trunk")
+      POD_SOURCE = Pod::Source.new(COCOAPODS_REPOS + "trunk")
+    else
+      POD_SOURCE = Pod::Source.new(COCOAPODS_REPOS + "master")
+    end
 
     def initialize(options = nil)
       if options.nil?


### PR DESCRIPTION
In case Cocoapods is used with trunk repo instead of master, the urls generated in the summary report are nil.
By checking the presence of trunk repo and using it, the issue is fixed.