### PR TITLE
Allowlist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASE]
 
+### Added
+
+- Handle allowlist in the file `.ad_licenselint.yml`
+
 ### Fixed
 
 - Search pod specification in both `trunk` and `master` sources

--- a/README.md
+++ b/README.md
@@ -159,6 +159,18 @@ If you want to see all the options available, display help:
 bundle exec ad_licenselint -h
 ```
 
+### Allow list
+
+You may want to hide warnings for pods you know are valid (for instance private pods that have a commercial license). For this purpose, you can create a file `.ad_licenselint.yml` next to your `Podfile` that looks like this:
+
+```yaml
+allow:
+- ObjectivePGP
+- SomeOtherPod
+```
+
+Next, when you will run `bundle exec ad_licenselint`, `ObjectivePGP` will not emit a warning anymore.
+
 ### Ruby
 
 If you want to use the the gem in your ruby scripts, you can generate a report like so:

--- a/lib/ad_licenselint/license_entry.rb
+++ b/lib/ad_licenselint/license_entry.rb
@@ -12,10 +12,6 @@ class LicenseEntry
     !pod_name.empty? && !license_name.empty?
   end
 
-  def is_accepted
-    ADLicenseLint::Constant::ACCEPTED_LICENSES.include?(license_name)
-  end
-
   def copyright
     (/Copyright(.*)$/.match license_content)[0]
   end

--- a/test/test_ad_licenselint.rb
+++ b/test/test_ad_licenselint.rb
@@ -2,8 +2,11 @@ $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 require 'minitest/autorun'
 require 'minitest/hooks/test'
 require 'ad_licenselint'
+require 'yaml'
+require 'fileutils'
 
 PODFILE_DIR = "test/TestLicenseCollector"
+CONFIG_PATH = File.join(PODFILE_DIR, ".ad_licenselint.yml")
 
 class TestCase < Minitest::Test
   include Minitest::Hooks
@@ -14,6 +17,10 @@ class ADLincenseLintTest < TestCase
   # from minitest-hooks
   def after_all
     install_pods(["Alamofire"])
+  end
+
+  def teardown
+    FileUtils.rm CONFIG_PATH if File.exist? CONFIG_PATH
   end
 
   def test_one_valid_pod
@@ -54,6 +61,28 @@ class ADLincenseLintTest < TestCase
       content = ADLicenseLint::Runner.new(options).run
       assert_includes content, "ObjectivePGP"
       assert_includes content, "BSD for non-commercial use"
+    }
+  end
+
+  def test_one_invalid_pod_with_allowlist
+    install_pods(["ObjectivePGP"])
+    write_allowlist(["ObjectivePGP", "OtherPod"])
+
+    [false, true].each { |all|
+      options = {
+        format: ADLicenseLint::Constant::TERMINAL_FORMAT_OPTION,
+        path: PODFILE_DIR,
+        all: all
+      }
+
+      content = ADLicenseLint::Runner.new(options).run
+      if all
+        assert_includes content, "ObjectivePGP"
+        assert_includes content, "BSD for non-commercial use"
+      else
+        refute_includes content, "ObjectivePGP"
+        refute_includes content, "BSD for non-commercial use"
+      end
     }
   end
 
@@ -139,5 +168,10 @@ end"""
     Dir.chdir(PODFILE_DIR) do
       system "bundle exec pod install > /dev/null"
     end
+  end
+
+  def write_allowlist(pods)
+    config = { "allow" => pods }
+    File.write(CONFIG_PATH, config.to_yaml)
   end
 end


### PR DESCRIPTION
We now can define a file `.ad_licenselint.yml` where we can specify the list of allowed pods like this:

```yaml
allow:
- ObjectivePGP
- SomeOtherPod
```